### PR TITLE
Fix --no-default-features compilation

### DIFF
--- a/src/explain.rs
+++ b/src/explain.rs
@@ -206,7 +206,7 @@ fn dump_fg(fg: &FeatGraph) -> anyhow::Result<()> {
 
     #[cfg(not(feature = "spawn_xdot"))]
     {
-        dot::render(&graph, &mut std::io::stdout())?;
+        dot::render(&fg, &mut std::io::stdout())?;
     }
 
     Ok(())


### PR DESCRIPTION
Compiling without xdot should now work, it currently fails due to

```
error[E0425]: cannot find value `graph` in this scope
   --> /home/martin/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-hackerman-0.2.3/src/explain.rs:209:22
    |
209 |         dot::render(&graph, &mut std::io::stdout())?;
    |                      ^^^^^ not found in this scope

For more information about this error, try `rustc --explain E0425`.
```

As far as I can tell, this is simply a mis-typed variable name. Since you seem to not have a CI, this needs a manual to test to check.